### PR TITLE
fix(TUP-33675):Throw "Invalid key name: mdm.encryption.key" in error log

### DIFF
--- a/studio-utils/pom.xml
+++ b/studio-utils/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.talend.studio</groupId>
     <artifactId>studio-utils</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     <packaging>jar</packaging>
 
     <name>studio-utils</name>

--- a/studio-utils/src/main/java/org/talend/utils/security/StudioKeyName.java
+++ b/studio-utils/src/main/java/org/talend/utils/security/StudioKeyName.java
@@ -34,6 +34,8 @@ public class StudioKeyName {
 
     public static final String KEY_MIGRATION = "migration.encryption.key";
 
+    public static final String KEY_MDM_ENCRYPTION = "mdm.encryption.key";
+
     private final String keyName;
 
     /**
@@ -56,7 +58,8 @@ public class StudioKeyName {
             return false;
         }
 
-        if (this.keyName.equals(KEY_MIGRATION_TOKEN) || this.keyName.equals(KEY_MIGRATION)) {
+        if (this.keyName.equals(KEY_MIGRATION_TOKEN) || this.keyName.equals(KEY_MIGRATION)
+                || KEY_MDM_ENCRYPTION.equals(this.keyName)) {
             return true;
         }
 
@@ -124,10 +127,12 @@ public class StudioKeyName {
         return "";
     }
 
+    @Override
     public int hashCode() {
         return this.keyName.hashCode();
     }
 
+    @Override
     public boolean equals(Object that) {
         if (this == that) {
             return true;
@@ -140,6 +145,7 @@ public class StudioKeyName {
         return this.keyName.equals(thatObj.getKeyName());
     }
 
+    @Override
     public String toString() {
         return this.keyName;
     }

--- a/studio-utils/src/test/java/org/talend/utils/security/StudioKeyNameTest.java
+++ b/studio-utils/src/test/java/org/talend/utils/security/StudioKeyNameTest.java
@@ -12,7 +12,11 @@
 // ============================================================================
 package org.talend.utils.security;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
@@ -26,7 +30,7 @@ public class StudioKeyNameTest {
 
         String[] validNames = new String[] { StudioKeyName.KEY_SYSTEM_DEFAULT, StudioKeyName.KEY_ROUTINE,
                 StudioKeyName.KEY_ROUTINE_PREFIX, StudioKeyName.KEY_SYSTEM_PREFIX, StudioKeyName.KEY_MIGRATION,
-                StudioKeyName.KEY_MIGRATION_TOKEN };
+                StudioKeyName.KEY_MIGRATION_TOKEN, StudioKeyName.KEY_MDM_ENCRYPTION };
         for (String n : validNames) {
             StudioKeyName sn = new StudioKeyName(n);
             assertNotNull(sn);


### PR DESCRIPTION
when studio start up